### PR TITLE
Allow scrolling in left column

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -2,6 +2,7 @@
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
+  overflow: scroll;
 }
 
 html {


### PR DESCRIPTION
When screen is too small, you can't see all of the fields, so this enables scrolling.